### PR TITLE
validated color fix

### DIFF
--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -358,7 +358,7 @@ export default {
                             ['==', ["feature-state", `v_${inf}`], false], '#ec747e',
                             ['==', ["feature-state", `v_${inf}`], true], '#00b6b0',
                             ['==', ['get', `v_${inf}`], false], '#ec747e',
-                            ['==', ['get', `v_${inf}`], true], '#ec747e',
+                            ['==', ['get', `v_${inf}`], true], '#00b6b0',
                             '#ffffff'
                         ],
                         'fill-opacity': [


### PR DESCRIPTION
fix so validated and true color is always teal, with previous bug it was switching to salmon after a re-fresh