### PR TITLE
Gunicorn Workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,6 @@ CMD service nginx restart \
     && gunicorn \
         --bind 0.0.0.0:4000 \
         --timeout 120 \
+        --workers 24 \
         'ml_enabler:create_app()' \
         --access-logfile -


### PR DESCRIPTION
### Context

According to the gunicorn docs there is only 1 worker created by default. This PR increases the default worker rate considerably.

cc/ @martham93 