### PR TITLE
Lambda Deps

### DIFF
--- a/api/cloudformation/prediction.template.js
+++ b/api/cloudformation/prediction.template.js
@@ -157,7 +157,7 @@ module.exports = {
                 Role: cf.importValue(cf.join([cf.ref('StackName'), '-lambda-role'])),
                 Handler: 'download_and_predict.handler.handler',
                 MemorySize: 512,
-                Runtime: 'python3.7',
+                Runtime: 'python3.8',
                 ReservedConcurrentExecutions: cf.ref('MaxConcurrency'),
                 Timeout: 240,
                 Environment: {

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,9 +1,9 @@
-boto3==1.20.15
-numpy==1.20.2
+boto3==1.20.33
+numpy==1.22.0
 rasterio==1.1.5
-mercantile==1.1.5
-requests==2.25.0
+mercantile==1.2.1
+requests==2.27.1
 geojson==2.5.0
 pillow==8.0.1
-shapely==1.6.4
+shapely==1.8.0
 affine==2.3.0


### PR DESCRIPTION
```
[ERROR] Runtime.ImportModuleError: Unable to import module 'download_and_predict.handler': bad magic number in 'affine': b'U\r\r\n'
Traceback (most recent call last):
```

Hopefully fix the above error by matching the lamda runtime (3.7) with the build runtime (3.8)