### PR TITLE
TileBase@3.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2021, Development Seed
+Copyright (c) 2022, Development Seed
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/api/lib/project/iteration/submission.js
+++ b/api/lib/project/iteration/submission.js
@@ -70,6 +70,7 @@ class Submission extends Generic {
         const sub = await super.from(pool, id);
 
         sub.storage = await S3.exists(`project/${pid}/iteration/${sub.iter_id}/submission-${sub.id}.geojson`);
+        sub.tiles = await S3.exists(`project/${pid}/iteration/${sub.iter_id}/submission-${sub.id}.tilebase`);
 
         return sub;
     }
@@ -78,15 +79,19 @@ class Submission extends Generic {
         if (!list.submissions.length) return list;
 
         const s3m = {};
-        (await S3.list(`project/${list.submissions[0].pid}/iteration/${list.submissions[0].iter_id}/submission-`)).forEach((l) => {
-            const match = l.Key.match(/submission-(\d+).geojson/);
-            if (!match) return;
+        const s3t = {};
 
-            s3m[match[1]] = l.Key;
+        (await S3.list(`project/${list.submissions[0].pid}/iteration/${list.submissions[0].iter_id}/submission-`)).forEach((l) => {
+            const geojson_match = l.Key.match(/submission-(\d+).geojson/);
+            if (geojson_match) s3m[geojson_match[1]] = l.Key;
+
+            const tiles_match = l.Key.match(/submission-(\d+).tilebase/);
+            if (tiles_match) s3t[tiles_match[1]] = l.Key;
         });
 
         for (const sub of list.submissions) {
             sub.storage = !!s3m[sub.id];
+            sub.tiles = !!s3t[sub.id];
         }
 
         return list;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -31,7 +31,7 @@
                 "pg": "^8.6.0",
                 "slonik": "^27.0.0",
                 "sns-validator": "^0.3.4",
-                "tilebase": "^2.0.0",
+                "tilebase": "^3.0.0",
                 "wkx": "^0.5.0"
             },
             "devDependencies": {
@@ -2472,6 +2472,14 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/deasync": {
             "version": "0.1.24",
             "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.24.tgz",
@@ -3875,6 +3883,28 @@
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
             "dev": true
         },
+        "node_modules/fetch-blob": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4027,6 +4057,17 @@
             },
             "engines": {
                 "node": ">= 0.12"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/forwarded": {
@@ -6400,6 +6441,24 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "engines": {
+                "node": ">=10.5.0"
+            }
         },
         "node_modules/node-fetch": {
             "version": "2.6.7",
@@ -9286,9 +9345,9 @@
             }
         },
         "node_modules/tilebase": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-2.0.0.tgz",
-            "integrity": "sha512-6E9GVN9KXd24ylrUsdL3Yki9/AodFPNGUzQkH+UlNqp3fG+Zh5Vm5eMI1hiD/fEX0n9H6qlOU5eURBcoUBXOWA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-3.0.0.tgz",
+            "integrity": "sha512-bR/EC79v8jsCRjCJDL5dyJrPlZGhM/wF4XOH+u7nEPy2PRpOdZa36fOoSCkNhEvMBG3Fqn7Wxw1JgrpU+CqzjA==",
             "dependencies": {
                 "@mapbox/mbtiles": "^0.12.1",
                 "@mapbox/tile-cover": "^3.0.2",
@@ -9300,12 +9359,32 @@
                 "ajv": "^8.2.0",
                 "aws-sdk": "^2.900.0",
                 "minimist": "^1.2.5",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^3.2.0",
                 "nyc": "^15.1.0",
                 "pbf": "^3.2.1"
             },
             "bin": {
                 "tilebase": "cli.js"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
+            }
+        },
+        "node_modules/tilebase/node_modules/node-fetch": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+            "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/to-fast-properties": {
@@ -9753,6 +9832,14 @@
             },
             "engines": {
                 "node": ">=4.0.0"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+            "engines": {
+                "node": ">= 8"
             }
         },
         "node_modules/webidl-conversions": {
@@ -12116,6 +12203,11 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+        },
         "deasync": {
             "version": "0.1.24",
             "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.24.tgz",
@@ -13144,6 +13236,15 @@
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
             "dev": true
         },
+        "fetch-blob": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+            "requires": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            }
+        },
         "file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -13266,6 +13367,14 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
+            }
+        },
+        "formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "requires": {
+                "fetch-blob": "^3.1.2"
             }
         },
         "forwarded": {
@@ -15027,6 +15136,11 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+        },
+        "node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
         },
         "node-fetch": {
             "version": "2.6.7",
@@ -17281,9 +17395,9 @@
             "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
         },
         "tilebase": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-2.0.0.tgz",
-            "integrity": "sha512-6E9GVN9KXd24ylrUsdL3Yki9/AodFPNGUzQkH+UlNqp3fG+Zh5Vm5eMI1hiD/fEX0n9H6qlOU5eURBcoUBXOWA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-3.0.0.tgz",
+            "integrity": "sha512-bR/EC79v8jsCRjCJDL5dyJrPlZGhM/wF4XOH+u7nEPy2PRpOdZa36fOoSCkNhEvMBG3Fqn7Wxw1JgrpU+CqzjA==",
             "requires": {
                 "@mapbox/mbtiles": "^0.12.1",
                 "@mapbox/tile-cover": "^3.0.2",
@@ -17295,9 +17409,21 @@
                 "ajv": "^8.2.0",
                 "aws-sdk": "^2.900.0",
                 "minimist": "^1.2.5",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^3.2.0",
                 "nyc": "^15.1.0",
                 "pbf": "^3.2.1"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+                    "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
+                    "requires": {
+                        "data-uri-to-buffer": "^4.0.0",
+                        "fetch-blob": "^3.1.4",
+                        "formdata-polyfill": "^4.0.10"
+                    }
+                }
             }
         },
         "to-fast-properties": {
@@ -17646,6 +17772,11 @@
                     "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
                 }
             }
+        },
+        "web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
         },
         "webidl-conversions": {
             "version": "3.0.1",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -31,7 +31,7 @@
                 "pg": "^8.6.0",
                 "slonik": "^27.0.0",
                 "sns-validator": "^0.3.4",
-                "tilebase": "^1.6.0",
+                "tilebase": "^2.0.0",
                 "wkx": "^0.5.0"
             },
             "devDependencies": {
@@ -9286,9 +9286,9 @@
             }
         },
         "node_modules/tilebase": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-1.6.1.tgz",
-            "integrity": "sha512-jl16kW5AyVwjFm7wR0OjL/tA5igOF704CEVxxZjOn5Ld+h96wZjOg0DWRFMfjO2NdrftdWFcwHtt4qba6QgEpg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-2.0.0.tgz",
+            "integrity": "sha512-6E9GVN9KXd24ylrUsdL3Yki9/AodFPNGUzQkH+UlNqp3fG+Zh5Vm5eMI1hiD/fEX0n9H6qlOU5eURBcoUBXOWA==",
             "dependencies": {
                 "@mapbox/mbtiles": "^0.12.1",
                 "@mapbox/tile-cover": "^3.0.2",
@@ -17281,9 +17281,9 @@
             "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
         },
         "tilebase": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-1.6.1.tgz",
-            "integrity": "sha512-jl16kW5AyVwjFm7wR0OjL/tA5igOF704CEVxxZjOn5Ld+h96wZjOg0DWRFMfjO2NdrftdWFcwHtt4qba6QgEpg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-2.0.0.tgz",
+            "integrity": "sha512-6E9GVN9KXd24ylrUsdL3Yki9/AodFPNGUzQkH+UlNqp3fG+Zh5Vm5eMI1hiD/fEX0n9H6qlOU5eURBcoUBXOWA==",
             "requires": {
                 "@mapbox/mbtiles": "^0.12.1",
                 "@mapbox/tile-cover": "^3.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -36,7 +36,7 @@
         "pg": "^8.6.0",
         "slonik": "^27.0.0",
         "sns-validator": "^0.3.4",
-        "tilebase": "^2.0.0",
+        "tilebase": "^3.0.0",
         "wkx": "^0.5.0"
     },
     "devDependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -36,7 +36,7 @@
         "pg": "^8.6.0",
         "slonik": "^27.0.0",
         "sns-validator": "^0.3.4",
-        "tilebase": "^1.6.0",
+        "tilebase": "^2.0.0",
         "wkx": "^0.5.0"
     },
     "devDependencies": {

--- a/api/routes/project-iteration-submission.js
+++ b/api/routes/project-iteration-submission.js
@@ -95,7 +95,7 @@ async function router(schema, config) {
             const tj = tb.tilejson();
             tj.token = config.Mapbox;
 
-            tj.tiles.push(`/api/project/${req.params.pid}/iteration/${req.params.iterationid}/submission/${req.params.subid}/tiles/{z}/{x}/{y}.mvt`);
+            tj.tiles.push(`/api/project/${req.params.pid}/iteration/${req.params.iterationid}/submission/${req.params.subid}/tiles/{z}/{x}/{y}.${tb.format()}`);
 
             return res.json(tj);
         } catch (err) {

--- a/api/routes/project-iteration-submission.js
+++ b/api/routes/project-iteration-submission.js
@@ -1,9 +1,10 @@
 'use strict';
 const { Err } = require('@openaddresses/batch-schema');
 const Submission = require('../lib/project/iteration/submission');
-const TileBase = require('tilebase');
 
 async function router(schema, config) {
+    const TileBase = (await import('tilebase')).default;
+
     const user = new (require('../lib/user'))(config);
 
     /**

--- a/api/schema/res.ListSubmission.json
+++ b/api/schema/res.ListSubmission.json
@@ -20,7 +20,8 @@
                     "created",
                     "iter_id",
                     "aoi_id",
-                    "storage"
+                    "storage",
+                    "tiles"
                 ],
                 "properties": {
                     "id": {
@@ -36,6 +37,9 @@
                         "type": "integer"
                     },
                     "storage": {
+                        "type": "boolean"
+                    },
+                    "tiles": {
                         "type": "boolean"
                     }
                 }

--- a/api/schema/res.Submission.json
+++ b/api/schema/res.Submission.json
@@ -6,7 +6,8 @@
         "aoi_id",
         "created",
         "iter_id",
-        "storage"
+        "storage",
+        "tiles"
     ],
     "properties": {
         "id": {
@@ -22,6 +23,9 @@
             "type": "integer"
         },
         "storage": {
+            "type": "boolean"
+        },
+        "tiles": {
             "type": "boolean"
         }
     }

--- a/api/web/src/components/iteration/Map.vue
+++ b/api/web/src/components/iteration/Map.vue
@@ -521,7 +521,7 @@ export default {
             try {
                 const res = await window.std(`/api/project/${this.$route.params.projectid}/iteration/${this.$route.params.iterationid}/submission`);
                 this.submissions = res.submissions.filter((s) => {
-                    return s.storage;
+                    return s.tiles;
                 });
             } catch (err) {
                 this.$emit('err', err);

--- a/tasks/task-vectorize/.eslintrc.json
+++ b/tasks/task-vectorize/.eslintrc.json
@@ -6,9 +6,12 @@
     },
     "globals": {
         "Map": true,
-        "Promise": true
+        "Promise": true,
+        "Uint8Array": true,
+        "BigInt": true
     },
     "parserOptions": {
+        "sourceType": "module",
         "ecmaVersion": 13
     },
     "plugins": [ "node" ],
@@ -39,7 +42,6 @@
         "keyword-spacing": [ "error", { "before": true, "after": true } ],
         "template-curly-spacing": [ "error", "never" ],
         "semi-spacing": "error",
-        "strict": "error",
         "node/no-missing-require": "error",
         "valid-jsdoc": ["error", {
             "requireParamDescription": false,

--- a/tasks/task-vectorize/index.js
+++ b/tasks/task-vectorize/index.js
@@ -1,11 +1,13 @@
 'use strict';
-const AWS = require('aws-sdk');
-const path = require('path');
-const fs = require('fs');
-const TileBase = require('tilebase');
-const Tippecanoe = require('./lib/tippecanoe');
-const B64PNG = require('./lib/b64png.js');
-const RL = require('readline');
+import { fileURLToPath } from 'url';
+import process from 'process';
+import AWS from 'aws-sdk';
+import path from 'path';
+import fs from 'fs';
+import TileBase from 'tilebase';
+import Tippecanoe from './lib/tippecanoe.js';
+import B64PNG from './lib/b64png.js';
+import RL from 'readline';
 
 /**
  * @class
@@ -25,7 +27,7 @@ class Task {
      * @param {boolean} [opts.silent=false] Should output be squelched
      */
     static async vectorize(input, opts = {}) {
-        if (!opts.tmp) opts.tmp = path.resolve(__dirname, './data/');
+        if (!opts.tmp) opts.tmp = new URL('./data/', import.meta.url).pathname;
         if (!opts.silent) opts.silent = false;
         if (!opts.bucket) {
             opts.bucket = false;
@@ -128,8 +130,8 @@ class Task {
     }
 }
 
-if (require.main === module) {
-    Task.vectorize(path.resolve(__dirname, './data/input.geojson'), {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    Task.vectorize(new URL('./data/input.geojson', import.meta.url).pathname, {
         silent: false,
         bucket: process.env.ASSET_BUCKET,
         project: process.env.PROJECT_ID,
@@ -138,4 +140,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = Task;
+export default Task;

--- a/tasks/task-vectorize/lib/b64png.js
+++ b/tasks/task-vectorize/lib/b64png.js
@@ -1,12 +1,12 @@
 'use strict';
-const fs = require('fs');
-const path = require('path');
-const RL = require('readline');
-const MBTiles = require('./mbtiles');
-const BBox = require('./bbox');
-const PNG = require('fast-png');
-const colour = require('randomcolor');
-const { Image } = require('image-js');
+import fs from 'fs';
+import path from 'path';
+import RL from 'readline';
+import MBTiles from './mbtiles.js';
+import BBox from './bbox.js';
+import PNG from 'fast-png';
+import colour from 'randomcolor';
+import { Image } from 'image-js';
 
 /**
  * @class
@@ -18,12 +18,12 @@ class B64PNG {
         if (palette) {
             this.palette = palette;
         } else {
-            this.palette = new Array(256).fill(
-                colour({ format: 'rgb' })
+            this.palette = new Array(256).fill().map(() => {
+                return colour({ format: 'rgb' })
                     .replace(/(rgb\(|\)|\s)/g, '')
                     .split(',')
-                    .map(e => parseInt(e))
-            );
+                    .map((e) => parseInt(e))
+            });
         }
     }
 
@@ -80,7 +80,7 @@ function exportPNG(image, options = {}) {
         height: image.height,
         channels: image.channels,
         depth: image.bitDepth,
-        data: image.data,
+        data: image.data
     };
 
     if (data.depth === 1 || data.depth === 32) {
@@ -123,9 +123,9 @@ function loadPNGFromPalette(png) {
     return new Image(png.width, png.height, data, {
         components: 3,
         alpha: hasAlpha,
-        bitDepth: 8,
+        bitDepth: 8
     });
 }
 
 
-module.exports = B64PNG;
+export default B64PNG;

--- a/tasks/task-vectorize/lib/bbox.js
+++ b/tasks/task-vectorize/lib/bbox.js
@@ -1,7 +1,7 @@
 'use strict';
-const SM = require('@mapbox/sphericalmercator');
-const bboxPolygon = require('@turf/bbox-polygon').default;
-const centroid = require('@turf/centroid').default;
+import SM from '@mapbox/sphericalmercator';
+import bboxPolygon from '@turf/bbox-polygon';
+import centroid from '@turf/centroid';
 const sm = new SM({
     size: 256,
     antimeridian: true
@@ -69,4 +69,4 @@ class BBox {
     }
 }
 
-module.exports = BBox;
+export default BBox;

--- a/tasks/task-vectorize/lib/mbtiles.js
+++ b/tasks/task-vectorize/lib/mbtiles.js
@@ -1,5 +1,5 @@
 'use strict';
-const MBT = require('@mapbox/mbtiles');
+import MBT from '@mapbox/mbtiles';
 
 class MBTiles {
     constructor(mbtiles) {
@@ -52,4 +52,4 @@ class MBTiles {
     }
 }
 
-module.exports = MBTiles;
+export default MBTiles;

--- a/tasks/task-vectorize/lib/tippecanoe.js
+++ b/tasks/task-vectorize/lib/tippecanoe.js
@@ -1,6 +1,6 @@
 'use strict';
-const CP = require('child_process');
-const stream = require('stream');
+import CP from 'child_process';
+import stream from 'stream';
 
 /**
  * Create a new Tippecanoe instance
@@ -121,4 +121,4 @@ class Tippecanoe {
     }
 }
 
-module.exports = Tippecanoe;
+export default Tippecanoe;

--- a/tasks/task-vectorize/package-lock.json
+++ b/tasks/task-vectorize/package-lock.json
@@ -17,7 +17,7 @@
                 "fast-png": "^6.1.0",
                 "image-js": "^0.33.1",
                 "randomcolor": "^0.6.2",
-                "tilebase": "^1.5.0"
+                "tilebase": "^3.0.0"
             },
             "devDependencies": {
                 "@mapbox/mock-aws-sdk-js": "^1.0.0",
@@ -1167,6 +1167,14 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1989,6 +1997,28 @@
                 "pako": "^2.0.4"
             }
         },
+        "node_modules/fetch-blob": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            }
+        },
         "node_modules/fft.js": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
@@ -2109,6 +2139,17 @@
             },
             "engines": {
                 "node": ">= 0.12"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/fromentries": {
@@ -3623,23 +3664,39 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+            "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
             "dependencies": {
-                "whatwg-url": "^5.0.0"
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
             },
             "engines": {
-                "node": "4.x || >=6.0.0"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/node-gyp": {
@@ -4811,9 +4868,9 @@
             }
         },
         "node_modules/tilebase": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-1.6.0.tgz",
-            "integrity": "sha512-uCvu5avTSGImkPkJ+jYZX9tmj16DXwwR+8GBdb+DA6LhkM06X2uvxOFXM/UT8q4aIfhr4YkFnnfiU9ZtL4AxmA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-3.0.0.tgz",
+            "integrity": "sha512-bR/EC79v8jsCRjCJDL5dyJrPlZGhM/wF4XOH+u7nEPy2PRpOdZa36fOoSCkNhEvMBG3Fqn7Wxw1JgrpU+CqzjA==",
             "dependencies": {
                 "@mapbox/mbtiles": "^0.12.1",
                 "@mapbox/tile-cover": "^3.0.2",
@@ -4825,12 +4882,15 @@
                 "ajv": "^8.2.0",
                 "aws-sdk": "^2.900.0",
                 "minimist": "^1.2.5",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^3.2.0",
                 "nyc": "^15.1.0",
                 "pbf": "^3.2.1"
             },
             "bin": {
                 "tilebase": "cli.js"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
             }
         },
         "node_modules/to-fast-properties": {
@@ -4853,11 +4913,6 @@
             "engines": {
                 "node": ">=0.8"
             }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
         },
         "node_modules/traverse": {
             "version": "0.6.6",
@@ -5012,24 +5067,18 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "optional": true
         },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/web-worker-manager": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/web-worker-manager/-/web-worker-manager-0.2.0.tgz",
             "integrity": "sha1-4bzkI8ZAt2xAlzH53pULsbkmZSE="
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -6193,6 +6242,11 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+        },
         "debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -6817,6 +6871,15 @@
                 "pako": "^2.0.4"
             }
         },
+        "fetch-blob": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+            "requires": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            }
+        },
         "fft.js": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
@@ -6910,6 +6973,14 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
+            }
+        },
+        "formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "requires": {
+                "fetch-blob": "^3.1.2"
             }
         },
         "fromentries": {
@@ -8122,12 +8193,19 @@
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
             "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
         },
+        "node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+        },
         "node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+            "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
             "requires": {
-                "whatwg-url": "^5.0.0"
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
             }
         },
         "node-gyp": {
@@ -9041,9 +9119,9 @@
             }
         },
         "tilebase": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-1.6.0.tgz",
-            "integrity": "sha512-uCvu5avTSGImkPkJ+jYZX9tmj16DXwwR+8GBdb+DA6LhkM06X2uvxOFXM/UT8q4aIfhr4YkFnnfiU9ZtL4AxmA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tilebase/-/tilebase-3.0.0.tgz",
+            "integrity": "sha512-bR/EC79v8jsCRjCJDL5dyJrPlZGhM/wF4XOH+u7nEPy2PRpOdZa36fOoSCkNhEvMBG3Fqn7Wxw1JgrpU+CqzjA==",
             "requires": {
                 "@mapbox/mbtiles": "^0.12.1",
                 "@mapbox/tile-cover": "^3.0.2",
@@ -9055,7 +9133,7 @@
                 "ajv": "^8.2.0",
                 "aws-sdk": "^2.900.0",
                 "minimist": "^1.2.5",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^3.2.0",
                 "nyc": "^15.1.0",
                 "pbf": "^3.2.1"
             }
@@ -9074,11 +9152,6 @@
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
             }
-        },
-        "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
         },
         "traverse": {
             "version": "0.6.6",
@@ -9215,24 +9288,15 @@
                 }
             }
         },
+        "web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
+        },
         "web-worker-manager": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/web-worker-manager/-/web-worker-manager-0.2.0.tgz",
             "integrity": "sha1-4bzkI8ZAt2xAlzH53pULsbkmZSE="
-        },
-        "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
         },
         "which": {
             "version": "2.0.2",

--- a/tasks/task-vectorize/package.json
+++ b/tasks/task-vectorize/package.json
@@ -1,5 +1,6 @@
 {
     "name": "task-vectorize",
+    "type": "module",
     "private": true,
     "version": "1.0.0",
     "description": "",
@@ -22,7 +23,7 @@
         "fast-png": "^6.1.0",
         "image-js": "^0.33.1",
         "randomcolor": "^0.6.2",
-        "tilebase": "^1.5.0"
+        "tilebase": "^3.0.0"
     },
     "devDependencies": {
         "@mapbox/mock-aws-sdk-js": "^1.0.0",

--- a/tasks/task-vectorize/test/feature.test.js
+++ b/tasks/task-vectorize/test/feature.test.js
@@ -1,9 +1,8 @@
 'use strict';
-const test = require('tape');
-const path = require('path');
-const os = require('os');
-const Task = require('..');
-const AWS = require('@mapbox/mock-aws-sdk-js');
+import test from 'tape';
+import os from 'os';
+import Task from '../index.js';
+import AWS from '@mapbox/mock-aws-sdk-js';
 
 test('Feature', async (t) => {
     AWS.stub('S3', 'putObject', function(params) {
@@ -16,7 +15,7 @@ test('Feature', async (t) => {
     });
 
     try {
-        await Task.vectorize(path.resolve(__dirname, './fixtures/feature.json'), {
+        await Task.vectorize(new URL('./fixtures/feature.json', import.meta.url).pathname, {
             tmp: os.tmpdir(),
             bucket: 's3-bucket',
             project: 1,
@@ -27,5 +26,6 @@ test('Feature', async (t) => {
         t.error(err);
     }
 
+    AWS.S3.restore();
     t.end();
 });

--- a/tasks/task-vectorize/test/image.test.js
+++ b/tasks/task-vectorize/test/image.test.js
@@ -1,9 +1,8 @@
 'use strict';
-const test = require('tape');
-const path = require('path');
-const os = require('os');
-const Task = require('..');
-const AWS = require('@mapbox/mock-aws-sdk-js');
+import test from 'tape';
+import os from 'os';
+import Task from '../index.js';
+import AWS from '@mapbox/mock-aws-sdk-js';
 
 test('Image', async (t) => {
     AWS.stub('S3', 'putObject', function(params) {
@@ -16,7 +15,7 @@ test('Image', async (t) => {
     });
 
     try {
-        await Task.vectorize(path.resolve(__dirname, './fixtures/image.json'), {
+        await Task.vectorize(new URL('./fixtures/image.json', import.meta.url).pathname, {
             tmp: os.tmpdir(),
             bucket: 's3-bucket',
             project: 1,
@@ -27,5 +26,6 @@ test('Image', async (t) => {
         t.error(err);
     }
 
+    AWS.S3.restore();
     t.end();
 });


### PR DESCRIPTION
### Context

- [x] Update TileBase@3.0.0
- [x] Update task-vectorize to MJS to more easily import TileBase and other ES modules
- [x] Tilebase now supports `format` & `name` properties for easier identification of tile type
- [x] Return proper TileJSON format type in `tiles[]` array
- [x] Add support for multiple formats to Get Tile API
- [x] Check that format being requested is the same via the new `TB#format()` call
- [x] Return PNGs with proper Content-Type
